### PR TITLE
Rename and change link to @unitedstates data

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@
 <li>The official Web site of the <a href="http://clerk.house.gov/legislative/legvotes.html">Office of the Clerk of the U.S. House of Representatives</a>, for vote data</li>
 <li>The official Web site of the <a href="http://www.senate.gov/pagelayout/legislative/a_three_sections_with_teasers/votes.htm">United States Senate</a>, for vote data</li>
 <li>The <a href="http://bioguide.congress.gov/biosearch/biosearch.asp">Biographical Directory of the United States Congress</a>, for member biographical information</li>
-<li>UnitedStates.io, for social media account names in member lists and some member biographical information</li>
+<li><a href="https://github.com/unitedstates/congress-legislators">the @unitedstates project</a>, for social media account names in member lists and some member biographical information</li>
 <li>MIT Professor Charles Stewart&rsquo;s collection of <a href="http://web.mit.edu/17.251/www/data_page.html">Congressional data</a>, for some role information</li>
 <li><a href="https://www.congress.gov/">Congress.gov</a> (The Library of Congress) and the <a href="https://www.gpo.gov/fdsys/bulkdata/BILLSUM">Government Printing Office</a>, for bill data and nomination data</li>
 </ul>


### PR DESCRIPTION
The link to the @unitedstates data isn't linked, and the domain was wrong (it's theunitedstates.io, not unitedstates.io). I just had it point right to the GitHub repository, since that's the data source.
